### PR TITLE
Update macOS CI to macos-15 and deployment target 15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,14 +47,14 @@ jobs:
             matrix: macos
             emoji: 🍎
             runs-on:
-              arm: [macos-13-arm64]
+              arm: [macos-15]
               intel: [macos-15-intel]
             cibw-archs-macos:
               arm: arm64
               intel: x86_64
             macosx-deployment-target:
-              arm: 13.0
-              intel: 13.0
+              arm: 15
+              intel: 15
           - name: Linux
             file-name: linux
             matrix: linux

--- a/.github/workflows/miniupnpc.yml
+++ b/.github/workflows/miniupnpc.yml
@@ -47,14 +47,14 @@ jobs:
             matrix: macos
             emoji: 🍎
             runs-on:
-              arm: [macos-13-arm64]
+              arm: [macos-15]
               intel: [macos-15-intel]
             cibw-archs-macos:
               arm: arm64
               intel: x86_64
             macosx-deployment-target:
-              arm: 13.0
-              intel: 13
+              arm: 15
+              intel: 15
           - name: Linux
             file-name: linux
             matrix: linux

--- a/.github/workflows/psutil.yml
+++ b/.github/workflows/psutil.yml
@@ -45,14 +45,14 @@ jobs:
             matrix: macos
             emoji: 🍎
             runs-on:
-              arm: [macos-13-arm64]
+              arm: [macos-15]
               intel: [macos-15-intel]
             cibw-archs-macos:
               arm: arm64
               intel: x86_64
             macosx-deployment-target:
-              arm: 13.0
-              intel: 13.0
+              arm: 15
+              intel: 15
           - name: Linux
             file-name: linux
             matrix: linux

--- a/.github/workflows/watchdog.yml
+++ b/.github/workflows/watchdog.yml
@@ -45,14 +45,14 @@ jobs:
             matrix: macos
             emoji: 🍎
             runs-on:
-              arm: [macos-13-arm64]
+              arm: [macos-15]
               intel: [macos-15-intel]
             cibw-archs-macos:
               arm: arm64
               intel: x86_64
             macosx-deployment-target:
-              arm: 13.0
-              intel: 13.0
+              arm: 15
+              intel: 15
         python:
           - major-dot-minor: "3.14"
             cibw-build: "cp314-*"


### PR DESCRIPTION
## Summary
- Move ARM macOS builds from `macos-13-arm64` to `macos-15`
- Set `MACOSX_DEPLOYMENT_TARGET=15` for both ARM and Intel macOS builds
- Apply consistently across `build.yml`, `watchdog.yml`, `psutil.yml`, and `miniupnpc.yml`

Aligns build-wheels with chiapos, chiavdf, and chia-blockchain.

## Test plan
- [ ] CI passes on macOS ARM and Intel matrix jobs for affected workflows